### PR TITLE
Added missed accents

### DIFF
--- a/Diacritics.Net45/Properties/AssemblyInfo.cs
+++ b/Diacritics.Net45/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Diacritics.Net45")]
-[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyCopyright("Copyright © 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.4")]
 [assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4-pre1")]
+[assembly: AssemblyFileVersion("1.0.4-pre2")]

--- a/Diacritics.NuGet/Package.nuspec
+++ b/Diacritics.NuGet/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Diacritics</id>
-    <version>1.0.4-pre1</version>
+    <version>1.0.4-pre2</version>
     <title>Diacritics.NET</title>
     <authors>Thomas Galliker</authors>
     <licenseUrl>http://opensource.org/licenses/Apache-2.0</licenseUrl>
@@ -22,6 +22,8 @@
     <releaseNotes>
       1.0.4-pre
       - Add .Net 4.5 implementation as dedicated assembly
+      - Add missing accents mappings
+      - Bug fix: Russian accents mapping fixed
       
       1.0.3
       - Bug fix: RemoveDiacritics now also removes upper case diacritic characters

--- a/Diacritics.NuGet/Properties/AssemblyInfo.cs
+++ b/Diacritics.NuGet/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Thomas Galliker")]
 [assembly: AssemblyProduct("Diacritics.NuGet")]
-[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyCopyright("Copyright © 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.4")]
 [assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4-pre1")]
+[assembly: AssemblyFileVersion("1.0.4-pre2")]

--- a/Diacritics.Shared/AccentMappings/OtherAccentsMapping.cs
+++ b/Diacritics.Shared/AccentMappings/OtherAccentsMapping.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Diacritics.AccentMappings
+{
+    public class OtherAccentsMapping : IAccentMapping
+    {
+        private static readonly IDictionary<char, char> MappingDictionary = new Dictionary<char, char>
+        {
+            { 'ė', 'e' },
+            { 'ÿ', 'y' },
+            { 'ū', 'u' },
+            { 'ī', 'i' },
+            { 'į', 'i' },
+            { 'ø', 'i' },
+            { 'ō', 'o' },
+            { 'å', 'a' },
+            { 'ā', 'a' }
+        };
+
+        public IDictionary<char, char> Mapping { get { return MappingDictionary; } }
+    }
+}

--- a/Diacritics.Shared/AccentMappings/OtherAccentsMapping.cs
+++ b/Diacritics.Shared/AccentMappings/OtherAccentsMapping.cs
@@ -11,7 +11,7 @@ namespace Diacritics.AccentMappings
             { 'ū', 'u' },
             { 'ī', 'i' },
             { 'į', 'i' },
-            { 'ø', 'i' },
+            { 'ø', 'o' },
             { 'ō', 'o' },
             { 'å', 'a' },
             { 'ā', 'a' }

--- a/Diacritics.Shared/AccentMappings/RussianAccentsMapping.cs
+++ b/Diacritics.Shared/AccentMappings/RussianAccentsMapping.cs
@@ -6,7 +6,8 @@ namespace Diacritics.AccentMappings
     {
         private static readonly IDictionary<char, char> MappingDictionary = new Dictionary<char, char>
         {
-            { 'ъ', 'b' },
+            { 'ё', 'e' },
+            { 'й', 'и' }
         };
 
         public IDictionary<char, char> Mapping { get { return MappingDictionary; } }

--- a/Diacritics.Shared/DefaultDiacriticsMapper.cs
+++ b/Diacritics.Shared/DefaultDiacriticsMapper.cs
@@ -28,7 +28,8 @@ namespace Diacritics
                 new SlovakianAccentsMapping(),
                 new SpanishAccentsMapping(),
                 new TurkishAccentsMapping(),
-                new UkarainianAccentsMapping())
+                new UkarainianAccentsMapping(),
+                new OtherAccentsMapping())
         {
         }
     }

--- a/Diacritics.Shared/Diacritics.Shared.projitems
+++ b/Diacritics.Shared/Diacritics.Shared.projitems
@@ -77,5 +77,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\StringExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDiacriticsMapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StaticDiacritics.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AccentMappings\OtherAccentsMapping.cs" />
   </ItemGroup>
 </Project>

--- a/Diacritics.Tests/DefaultDiacriticsMapperTests.cs
+++ b/Diacritics.Tests/DefaultDiacriticsMapperTests.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -28,7 +28,7 @@ namespace Diacritics.Tests
             stopwatch.Stop();
 
             // Assert
-            defaultDiacriticsMapping.Should().HaveCount(92);
+            defaultDiacriticsMapping.Should().HaveCount(103);
             this.testOutputHelper.WriteLine("stopwatch.ElapsedMilliseconds = {0}ms", stopwatch.ElapsedMilliseconds);
             stopwatch.ElapsedMilliseconds.Should().BeLessThan(50);
         }

--- a/Diacritics.Tests/Properties/AssemblyInfo.cs
+++ b/Diacritics.Tests/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Thomas Galliker")]
 [assembly: AssemblyProduct("Diacritics.Tests")]
-[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyCopyright("Copyright © 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.4")]
 [assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4-pre1")]
+[assembly: AssemblyFileVersion("1.0.4-pre2")]

--- a/Diacritics/Properties/AssemblyInfo.cs
+++ b/Diacritics/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Thomas Galliker")]
 [assembly: AssemblyProduct("Diacritics.NET")]
-[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyCopyright("Copyright © 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.4")]
 [assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4-pre1")]
+[assembly: AssemblyFileVersion("1.0.4-pre2")]


### PR DESCRIPTION
I've noticed, that some accents not removed by RemoveDiacritics(), so I added OtherAccentsMapping for all accents that was found with Mac keyboard, and made couple fixes for Russian language. 
"Ъ" character is not diacritic, it's two independent symbols "Ъ" and "Ь", and it's not necessary map one to another. In common case, when we trying to make accents-insensitive search or whatever, matches with "Ь" instead of "Ъ" will be totally invalid.  