### PR TITLE
Feature/replace current mapper

### DIFF
--- a/Diacritics/StaticDiacritics.cs
+++ b/Diacritics/StaticDiacritics.cs
@@ -1,8 +1,8 @@
-﻿namespace Diacritics
-{
-    using System;
-    using System.Threading;
+﻿using System;
+using System.Threading;
 
+namespace Diacritics
+{
     public static class StaticDiacritics
     {
         private static Lazy<IDiacriticsMapper> implementation;

--- a/Diacritics/StaticDiacritics.cs
+++ b/Diacritics/StaticDiacritics.cs
@@ -1,23 +1,27 @@
-﻿using System;
-
-namespace Diacritics
+﻿namespace Diacritics
 {
+    using System;
+    using System.Threading;
+
     public static class StaticDiacritics
     {
-        static readonly Lazy<IDiacriticsMapper> Implementation = new Lazy<IDiacriticsMapper>(CreateDefaultDiacriticsMapper, System.Threading.LazyThreadSafetyMode.PublicationOnly);
+        private static Lazy<IDiacriticsMapper> implementation;
 
-        public static IDiacriticsMapper Current
+        static StaticDiacritics()
         {
-            get
-            {
-                return Implementation.Value;
-            }
+            SetDefaultMapper(CreateDefaultDiacriticsMapper);
         }
 
-        static IDiacriticsMapper CreateDefaultDiacriticsMapper()
+        public static IDiacriticsMapper Current => implementation.Value;
+
+        public static void SetDefaultMapper(Func<IDiacriticsMapper> factory)
+        {
+            implementation = new Lazy<IDiacriticsMapper>(factory, LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        private static IDiacriticsMapper CreateDefaultDiacriticsMapper()
         {
             return new DefaultDiacriticsMapper();
         }
     }
 }
-

--- a/Tests/Diacritics.Tests/DefaultDiacriticsMapperTests.cs
+++ b/Tests/Diacritics.Tests/DefaultDiacriticsMapperTests.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 
 namespace Diacritics.Tests
 {
+    [Collection("StaticDiacritics")]
     public class DefaultDiacriticsMapperTests
     {
         private readonly ITestOutputHelper testOutputHelper;

--- a/Tests/Diacritics.Tests/Diacritics.Tests.csproj
+++ b/Tests/Diacritics.Tests/Diacritics.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>
 
   <!-- Include files in the Resources directory to be used across the test suite -->
@@ -26,5 +27,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Diacritics\Diacritics.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <PackageReference Include="Moq">
+      <Version>4.13.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Tests/Diacritics.Tests/Extensions/StringExtensionsTests.cs
+++ b/Tests/Diacritics.Tests/Extensions/StringExtensionsTests.cs
@@ -1,31 +1,23 @@
-﻿namespace Diacritics.Tests.Extensions
+﻿using System;
+using Diacritics.Extensions;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Diacritics.Tests.Extensions
 {
-    using System;
-
-    using Diacritics.Extensions;
-
-    using FluentAssertions;
-
-    using Moq;
-
-    using Xunit;
-
+    [Collection("StaticDiacritics")]
     public class StringExtensionsTests : IDisposable
     {
-        public void Dispose()
-        {
-            StaticDiacritics.SetDefaultMapper(() => new DefaultDiacriticsMapper());
-        }
-
         [Fact]
         public void ShouldCallRemoveDiacriticsOnCustomMapperWhenCallRemoveDiacritics()
         {
-            //Arrange
+            // Arrange
             const string expectedValue = "it s work";
             const string value = "ÉÖüä$üàè";
             var diacriticsMapperMock = new Mock<IDiacriticsMapper>();
             diacriticsMapperMock.Setup(mapper => mapper.RemoveDiacritics(value))
-                                .Returns(expectedValue);
+                .Returns(expectedValue);
             StaticDiacritics.SetDefaultMapper(() => diacriticsMapperMock.Object);
 
             // Act
@@ -71,6 +63,11 @@
                 this.Add("étoile", (true, "etoile"));
                 this.Add("İngiltere", (true, "Ingiltere"));
             }
+        }
+
+        public void Dispose()
+        {
+            StaticDiacritics.SetDefaultMapper(() => new DefaultDiacriticsMapper());
         }
     }
 }

--- a/Tests/Diacritics.Tests/Extensions/StringExtensionsTests.cs
+++ b/Tests/Diacritics.Tests/Extensions/StringExtensionsTests.cs
@@ -1,11 +1,40 @@
-﻿using Diacritics.Extensions;
-using FluentAssertions;
-using Xunit;
-
-namespace Diacritics.Tests.Extensions
+﻿namespace Diacritics.Tests.Extensions
 {
-    public class StringExtensionsTests
+    using System;
+
+    using Diacritics.Extensions;
+
+    using FluentAssertions;
+
+    using Moq;
+
+    using Xunit;
+
+    public class StringExtensionsTests : IDisposable
     {
+        public void Dispose()
+        {
+            StaticDiacritics.SetDefaultMapper(() => new DefaultDiacriticsMapper());
+        }
+
+        [Fact]
+        public void ShouldCallRemoveDiacriticsOnCustomMapperWhenCallRemoveDiacritics()
+        {
+            //Arrange
+            const string expectedValue = "it s work";
+            const string value = "ÉÖüä$üàè";
+            var diacriticsMapperMock = new Mock<IDiacriticsMapper>();
+            diacriticsMapperMock.Setup(mapper => mapper.RemoveDiacritics(value))
+                                .Returns(expectedValue);
+            StaticDiacritics.SetDefaultMapper(() => diacriticsMapperMock.Object);
+
+            // Act
+            var actual = value.RemoveDiacritics();
+
+            // Assert
+            actual.Should().Be(expectedValue);
+        }
+
         [Theory]
         [ClassData(typeof(DiacriticsTestData))]
         public void ShouldRemoveDiacritics(string input, (bool, string) expectedOutput)

--- a/Tests/Diacritics.Tests/StaticDiacriticsTests.cs
+++ b/Tests/Diacritics.Tests/StaticDiacriticsTests.cs
@@ -1,0 +1,36 @@
+﻿namespace Diacritics.Tests
+{
+    using System;
+
+    using FluentAssertions;
+
+    using Moq;
+
+    using Xunit;
+
+    public class StaticDiacriticsTests : IDisposable
+    {
+        public void Dispose()
+        {
+            StaticDiacritics.SetDefaultMapper(() => new DefaultDiacriticsMapper());
+        }
+
+        [Fact]
+        public void ShouldCanReplaceDefaultImplementationOfCurrentMapper()
+        {
+            var diacriticsMapperMock = new Mock<IDiacriticsMapper>();
+            StaticDiacritics.SetDefaultMapper(() => diacriticsMapperMock.Object);
+            var diacriticsMapper = StaticDiacritics.Current;
+
+            diacriticsMapper.Should().BeSameAs(diacriticsMapperMock.Object);
+        }
+
+        [Fact]
+        public void ShouldReturnDefaultDiacriticsMapperWhenCallCurrent()
+        {
+            var diacriticsMapper = StaticDiacritics.Current;
+
+            diacriticsMapper.Should().BeOfType<DefaultDiacriticsMapper>();
+        }
+    }
+}

--- a/Tests/Diacritics.Tests/StaticDiacriticsTests.cs
+++ b/Tests/Diacritics.Tests/StaticDiacriticsTests.cs
@@ -1,36 +1,39 @@
-﻿namespace Diacritics.Tests
+﻿using System;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Diacritics.Tests
 {
-    using System;
-
-    using FluentAssertions;
-
-    using Moq;
-
-    using Xunit;
-
     public class StaticDiacriticsTests : IDisposable
     {
-        public void Dispose()
-        {
-            StaticDiacritics.SetDefaultMapper(() => new DefaultDiacriticsMapper());
-        }
-
         [Fact]
         public void ShouldCanReplaceDefaultImplementationOfCurrentMapper()
         {
+            // Arrange
             var diacriticsMapperMock = new Mock<IDiacriticsMapper>();
+           
+            // Act
             StaticDiacritics.SetDefaultMapper(() => diacriticsMapperMock.Object);
             var diacriticsMapper = StaticDiacritics.Current;
 
+            // Assert
             diacriticsMapper.Should().BeSameAs(diacriticsMapperMock.Object);
         }
 
         [Fact]
         public void ShouldReturnDefaultDiacriticsMapperWhenCallCurrent()
         {
+            // Act
             var diacriticsMapper = StaticDiacritics.Current;
 
+            // Assert
             diacriticsMapper.Should().BeOfType<DefaultDiacriticsMapper>();
+        }
+
+        public void Dispose()
+        {
+            StaticDiacritics.SetDefaultMapper(() => new DefaultDiacriticsMapper());
         }
     }
 }

--- a/Tests/Diacritics.Tests/StaticDiacriticsTests.cs
+++ b/Tests/Diacritics.Tests/StaticDiacriticsTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Diacritics.Tests
 {
+    [Collection("StaticDiacritics")]
     public class StaticDiacriticsTests : IDisposable
     {
         [Fact]


### PR DESCRIPTION
I would like change the default diacritics mapper into static diacritics because the stringextensions use it into implementation. I know, I can inject diacritics into contructor but i would like use stringextensions methods with custom AccentMapping