### PR TITLE
add missing icelandic letters

### DIFF
--- a/Diacritics/AccentMappings/IcelandicAccentsMapping.Extensions.cs
+++ b/Diacritics/AccentMappings/IcelandicAccentsMapping.Extensions.cs
@@ -1,0 +1,15 @@
+namespace Diacritics.AccentMappings
+{
+    public partial class IcelandicAccentsMapping : IAccentMapping
+    {
+        static IcelandicAccentsMapping()
+        {
+            MappingDictionary.Add('þ', "th");
+            MappingDictionary.Add('Þ', "Th");
+            MappingDictionary.Add('ð', "d");
+            MappingDictionary.Add('Ð', "D");
+            MappingDictionary.Add('æ', "ae");
+            MappingDictionary.Add('Æ', "Ae");
+        }
+    }
+}


### PR DESCRIPTION
`IcelandicAccentsMapping` covers only the seven accented vowels. Thorn, eth and
ash have no Unicode decomposition and are absent from the table, so
`RemoveDiacritics` passes them through unchanged:

    "Sigurðsson".RemoveDiacritics()  // "Sigurðsson", unchanged

Adds þ→th, Þ→Th, ð→d, Ð→D, æ→ae, Æ→Ae via `IcelandicAccentsMapping.Extensions.cs`,
following the existing French/Azerbaijani extension pattern.

Lowercase `æ` currently resolves only because French contributes it; `Æ` resolves
nowhere. Declaring both keeps Icelandic self-contained.

No behaviour change — all six were previously unmapped here.